### PR TITLE
Reduced constructor parameters to reduce errors

### DIFF
--- a/contracts/AppLogic.sol
+++ b/contracts/AppLogic.sol
@@ -35,7 +35,6 @@ contract AppLogic is SuperAppBase, Initializable {
 
     function initialize(
         address _host,
-        address _acceptedToken,
         address _locker,
         uint96 _minFlowRate
     )
@@ -43,7 +42,6 @@ contract AppLogic is SuperAppBase, Initializable {
         initializer
     {
         if(_host == address(0)) revert Errors.HostRequired();
-        if(_acceptedToken == address(0)) revert Errors.SuperTokenRequired();
         if(_locker == address(0)) revert Errors.LockerRequired();
 
         cfaV1Lib = CFAv1Library.InitData(
@@ -53,8 +51,8 @@ contract AppLogic is SuperAppBase, Initializable {
             )
         );
         
-        acceptedToken = ISuperToken(_acceptedToken);
         locker = ILocker(_locker);
+        acceptedToken = ISuperToken(locker.tokenAddress);
         minFlowRate = _minFlowRate;
     }
 

--- a/contracts/AppLogic.sol
+++ b/contracts/AppLogic.sol
@@ -36,7 +36,6 @@ contract AppLogic is SuperAppBase, Initializable {
     function initialize(
         address _host,
         address _locker,
-        uint96 _minFlowRate
     )
         external
         initializer
@@ -53,7 +52,12 @@ contract AppLogic is SuperAppBase, Initializable {
         
         locker = ILocker(_locker);
         acceptedToken = ISuperToken(locker.tokenAddress);
-        minFlowRate = _minFlowRate;
+        syncPrice();
+    }
+
+    // calculating minFlowRate based on lock price divided by duration
+    function syncPrice() public {
+        minFlowRate = locker.keyPrice / locker.expirationDuration; 
     }
 
     // tranfers all tokens held by this contract (this is just a fallback, usually not needed)

--- a/contracts/CloneFactory.sol
+++ b/contracts/CloneFactory.sol
@@ -7,7 +7,7 @@ import {AppLogic} from "./AppLogic.sol";
 
 contract CloneFactory {
 
-    event NewAppLogic(address indexed newApp, address host, address indexed locker, uint96 minFlowRate);
+    event NewAppLogic(address indexed newApp, address host, address indexed locker);
 
     uint256 immutable configWord = SuperAppDefinitions.APP_LEVEL_FINAL |
     SuperAppDefinitions.BEFORE_AGREEMENT_CREATED_NOOP;
@@ -21,16 +21,15 @@ contract CloneFactory {
     }
 
     function deployNewApp(
-        address locker,
-        uint96 minFlowRate
+        address locker
     )
         external
         returns(address)
     {
         address newAppClone = Clones.clone(address(appLogicImplementation));
-        AppLogic(newAppClone).initialize(host, locker, minFlowRate);
+        AppLogic(newAppClone).initialize(host, locker);
         ISuperfluid(host).registerAppByFactory(ISuperApp(newAppClone), configWord);
-        emit NewAppLogic(newAppClone, host, locker, minFlowRate);
+        emit NewAppLogic(newAppClone, host, locker);
         return newAppClone;
     }
 

--- a/contracts/CloneFactory.sol
+++ b/contracts/CloneFactory.sol
@@ -13,13 +13,14 @@ contract CloneFactory {
     SuperAppDefinitions.BEFORE_AGREEMENT_CREATED_NOOP;
 
     AppLogic public appLogicImplementation;
+    address private immutable host;
 
-    constructor(AppLogic _appLogicImplementation) {
+    constructor(AppLogic _appLogicImplementation, address _host) {
         appLogicImplementation = _appLogicImplementation;
+        host = _host;
     }
 
     function deployNewApp(
-        address host,
         address acceptedToken,
         address locker,
         uint96 minFlowRate

--- a/contracts/CloneFactory.sol
+++ b/contracts/CloneFactory.sol
@@ -7,7 +7,7 @@ import {AppLogic} from "./AppLogic.sol";
 
 contract CloneFactory {
 
-    event NewAppLogic(address indexed newApp, address host, address indexed acceptedToken, address indexed locker, uint96 minFlowRate);
+    event NewAppLogic(address indexed newApp, address host, address indexed locker, uint96 minFlowRate);
 
     uint256 immutable configWord = SuperAppDefinitions.APP_LEVEL_FINAL |
     SuperAppDefinitions.BEFORE_AGREEMENT_CREATED_NOOP;
@@ -21,7 +21,6 @@ contract CloneFactory {
     }
 
     function deployNewApp(
-        address acceptedToken,
         address locker,
         uint96 minFlowRate
     )
@@ -29,9 +28,9 @@ contract CloneFactory {
         returns(address)
     {
         address newAppClone = Clones.clone(address(appLogicImplementation));
-        AppLogic(newAppClone).initialize(host, acceptedToken, locker, minFlowRate);
+        AppLogic(newAppClone).initialize(host, locker, minFlowRate);
         ISuperfluid(host).registerAppByFactory(ISuperApp(newAppClone), configWord);
-        emit NewAppLogic(newAppClone, host, acceptedToken, locker, minFlowRate);
+        emit NewAppLogic(newAppClone, host, locker, minFlowRate);
         return newAppClone;
     }
 


### PR DESCRIPTION
I changed the code, but not the tests, please double check.

Basically now the constructor only requires the **lock** address, so there's a much smaller possibility of making errors. Everything else is pulled from the lock contract itself. 